### PR TITLE
Fixing description of the -f param on readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Before migration - copy and backup the database files somewhere safe:
 Open a shell terminal and navigate into the `h2-v2-migration` git repo. Execute the `migration.sh` shell command.
 
     
-    $_>/bin/sh migration.sh -f ${backup_directory}/grailsdb.mv.db -u ${username} -p ${password}
+    $_>/bin/sh migration.sh -f ${backup_directory}/grailsdb -u ${username} -p ${password}
     
 
-- The `-f` parameter is required and should be the full path to the backup database file.
+- The `-f` parameter is required and should be the full path to the backup database file without the extension.
 - The optional `-u` parameter is used for database username. If it is not provided, an empty string will be used.
 - The optional `-p` parameter is used for database password. If it is not provided, an empty string will be used. 
 


### PR DESCRIPTION
The `-f` params should not have extension of the database file name.

instead of `-f ${dir}/databasefile.mv.db` it should be `-f ${dir}/databasefile`