### PR TITLE
Prepend relative pathname character to file variable if not provided

### DIFF
--- a/migration.sh
+++ b/migration.sh
@@ -44,7 +44,7 @@ echo "===> Jdbc drivers downloaded."
 echo ""
 
 echo "===> Start to export database into SQL script: "
-java -cp $OUTPUT_DIR/h2-1.4.200.jar org.h2.tools.Script -url "jdbc:h2:$file" -user "$username" -password "$password" -script "./$OUTPUT_DIR/backup.sql"
+java -cp $OUTPUT_DIR/h2-1.4.200.jar org.h2.tools.Script -url "jdbc:h2:${file:+./$file}" -user "$username" -password "$password" -script "./$OUTPUT_DIR/backup.sql"
 echo "===> Done export."
 echo ""
 


### PR DESCRIPTION
This patch will prepend "./" characters to the provided $file variable if the path to the DB is not provided correctly. Calling the script currently like this

`./migration.sh -f db_backup/rundeckdb` 

will result in a following error:

`Exception in thread "main" org.h2.jdbc.JdbcSQLNonTransientConnectionException: A file path that is implicitly relative to the current working directory is not allowed in the database URL "jdbc:h2:db_backup/rundeckdb". Use an absolute path, ~/name, ./name, or the baseDir setting instead.`

It will only work if called like this:
`./migration.sh -f ./db_backup/rundeckdb`

This patch should allow running the script both ways.